### PR TITLE
feat(mcp-server): improve salt generation

### DIFF
--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import express from 'express';
 import { z } from 'zod';
 import { Wallet, TypedDataDomain, keccak256, AbiCoder, getBytes, verifyTypedData, randomBytes } from 'ethers';
+import { randomBytes as nodeRandomBytes } from 'crypto';
 import { callHash, type TxIntent as TxIntentType } from '@canopy/attest';
 import { PolicyEngine, type Decision } from './policy.js';
 
@@ -190,7 +191,7 @@ app.post('/eas/attest', async (req, res) => {
     revocable: true,
     refUID: '0x' + '0'.repeat(64),
     data,
-    salt: '0x' + Buffer.from(randomBytes ? randomBytes(32) : getBytes(keccak256(getBytes(issuer.privateKey)))).toString('hex')
+    salt: '0x' + Buffer.from(randomBytes ? randomBytes(32) : nodeRandomBytes(32)).toString('hex')
   };
 
   try {


### PR DESCRIPTION
## Summary
- import Node crypto randomBytes fallback
- remove private-key based salt derivation in EAS attestation

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.0.0.tgz; Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68b899293f8083228b77c176e471f560