### PR TITLE
docs: remove NGMI slang from contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+We appreciate your interest in improving Canopy. Please follow these guidelines:
+
+- Adhere to code style and commit message conventions.
+- Execute the test suite before shipping:
+  ```sh
+  pnpm test
+  ```
+- Open a pull request describing your changes.


### PR DESCRIPTION
## Summary
- add a contributing guide with neutral wording for running tests

## Testing
- `pnpm test` *(fails: Error when performing request to https://registry.npmjs.org/pnpm/-/pnpm-10.0.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a3e5bd2c83229c85e82f41535d6a