### PR TITLE
docs: document transaction flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Canopy turns an intended transaction into a short‑lived, verifiable capability
 - `examples.http`: Ready‑to‑run requests for local testing.
 - `Makefile`: Shortcuts for setup/dev/build/test.
 
+## Architecture
+Canopy converts a `txIntent` into a call‑bound capability in three steps:
+
+1. Build `txIntent`.
+2. `POST /policy/evaluate` → `{ decision, callHash, expiry, nonce, capabilitySig }`.
+3. Send the call with the capability proof; the destination or `POST /proof/verify` validates it.
+
+Read [docs/architecture.md](docs/architecture.md) for diagrams, endpoint details, and EIP‑712 structures.
+
 ## Setup & Run
 ```bash
 pnpm install                # install workspace deps

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,48 @@
+# Architecture
+
+Canopy turns a transaction intent into a short-lived capability bound to a specific on-chain call.
+
+## Flow
+
+1. Build `txIntent` (`chainId`, `subject`, `target`, `value`, `selector`, `args`, `policyId`).
+2. `POST /policy/evaluate` → `{ decision, artifacts: { callHash, expiry, nonce, capabilitySig } }`.
+3. Attach proof to the on-chain call; the destination/validator verifies (or preflight via `POST /proof/verify`).
+
+```mermaid
+sequenceDiagram
+    actor Client
+    participant Policy as Policy API
+    participant Dest as Destination
+    Client->>Client: Build txIntent
+    Client->>Policy: POST /policy/evaluate
+    Policy-->>Client: decision + artifacts
+    Client->>Dest: Call + capability proof
+    Dest-->>Client: execute if proof valid
+    Client->>Policy: POST /proof/verify (optional)
+```
+
+## Endpoints
+
+- `GET /health/ping`
+- `POST /policy/evaluate`
+- `POST /capability/issue`
+- `POST /proof/verify`
+
+## Call binding
+
+```
+callHash = keccak256(abi.encode(
+  chainid, target, subject, selector, value, keccak256(args)
+))
+```
+
+## Capability (EIP-712)
+
+Domain: `{ name:"Canopy", version:"1", chainId, verifyingContract: verifier }`
+
+Type: `CompliantCall(subject, verifier, target, value, argsHash, policyId, expiry, nonce)`
+
+## Safety
+
+- Short TTL (e.g., 60s), single-use nonce, issuer allowlist.
+- Normalize inputs: checksummed `0x` addresses, 4-byte selector, raw args (no selector).


### PR DESCRIPTION
## Summary
- add architecture doc covering txIntent → policy evaluation → proof verification with sequence diagram
- summarize the three-step flow in README and link to detailed architecture

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.0.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a848d2ac83228d2cab4f644b47fc